### PR TITLE
ProjectMetricsCalculator...

### DIFF
--- a/ArchiMetrics.Analysis/ArchiMetrics.Analysis.csproj
+++ b/ArchiMetrics.Analysis/ArchiMetrics.Analysis.csproj
@@ -48,7 +48,6 @@
     <Compile Include="Metrics\MemberDocumentationFactory.cs" />
     <Compile Include="Metrics\MetricsRepository.cs" />
     <Compile Include="Metrics\ProjectMetric.cs" />
-    <Compile Include="Metrics\ProjectMetricsCalculator.cs" />
     <Compile Include="Metrics\TypeDocumentation.cs" />
     <Compile Include="Metrics\TypeDocumentationFactory.cs" />
     <Compile Include="Model\CodeErrorRepository.cs" />
@@ -61,6 +60,7 @@
     <Compile Include="Model\StaticModelNode.cs" />
     <Compile Include="Model\SyntaxTransformer.cs" />
     <Compile Include="Model\TransformerBase.cs" />
+    <Compile Include="ProjectMetricsCalculator.cs" />
     <Compile Include="ReferenceResolvers\ReferencedSymbol.cs" />
     <Compile Include="ReferenceResolvers\ReferenceLocation.cs" />
     <Compile Include="ReferenceResolvers\ReferenceRepository.cs" />

--- a/ArchiMetrics.Analysis/ProjectMetricsCalculator.cs
+++ b/ArchiMetrics.Analysis/ProjectMetricsCalculator.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ProjectMetricsCalculator.cs" company="Reimers.dk">
-//   Copyright © Reimers.dk 2014
+//   Copyright Â© Reimers.dk 2014
 //   This source is subject to the Microsoft Public License (Ms-PL).
 //   Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
 //   All other rights reserved.
@@ -10,16 +10,17 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace ArchiMetrics.Analysis.Metrics
+namespace ArchiMetrics.Analysis
 {
 	using System.Collections.Generic;
 	using System.Linq;
 	using System.Threading.Tasks;
 	using ArchiMetrics.Common;
 	using ArchiMetrics.Common.Metrics;
+	using Metrics;
 	using Microsoft.CodeAnalysis;
 
-	internal class ProjectMetricsCalculator : IProjectMetricsCalculator
+	public class ProjectMetricsCalculator : IProjectMetricsCalculator
 	{
 		private readonly ICodeMetricsCalculator _metricsCalculator;
 


### PR DESCRIPTION
 is now publicly visible to be consumed as part of the public API, meaning that IProjectMetric can now be returned for Project level metrics.