### PR TITLE
cope better with malformed XML comments

### DIFF
--- a/src/ArchiMetrics.Analysis/ArchiMetrics.Analysis.csproj
+++ b/src/ArchiMetrics.Analysis/ArchiMetrics.Analysis.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Common\Structure\IVertexRepository.cs" />
     <Compile Include="Common\Structure\TransformRule.cs" />
     <Compile Include="CoverageAnalyzer.cs" />
+    <Compile Include="Metrics\FaultMemberDocumentation.cs" />
     <Compile Include="Metrics\MemberDocumentation.cs" />
     <Compile Include="Metrics\MemberDocumentationFactory.cs" />
     <Compile Include="Metrics\MetricsRepository.cs" />

--- a/src/ArchiMetrics.Analysis/Metrics/FaultMemberDocumentation.cs
+++ b/src/ArchiMetrics.Analysis/Metrics/FaultMemberDocumentation.cs
@@ -1,0 +1,43 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="FaultMemberDocumentation.cs" company="Reimers.dk">
+//   Copyright © Matthias Friedrich, Reimers.dk 2014
+//   This source is subject to the MIT License.
+//   Please see https://opensource.org/licenses/MIT for details.
+//   All other rights reserved.
+// </copyright>
+// <summary>
+//   Defines the FaultMemberDocumentation type.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ArchiMetrics.Analysis.Metrics
+{
+    using System.Collections.Generic;
+    using ArchiMetrics.Analysis.Common.Metrics;
+
+    internal class FaultMemberDocumentation : IMemberDocumentation
+    {
+        private readonly string _rawComment;
+
+        public FaultMemberDocumentation(string rawComment)
+        {
+            _rawComment = rawComment;
+        }
+
+        public string Summary => _rawComment;
+
+        public string Returns => _rawComment;
+
+        public string Code => _rawComment;
+
+        public string Example => _rawComment;
+
+        public string Remarks => _rawComment;
+
+        public IEnumerable<ParameterDocumentation> Parameters { get { yield break; } }
+
+        public IEnumerable<TypeParameterDocumentation> TypeParameters { get { yield break; } }
+
+        public IEnumerable<ExceptionDocumentation> Exceptions { get { yield break; } }
+    }
+}

--- a/src/ArchiMetrics.Analysis/Metrics/MemberDocumentationFactory.cs
+++ b/src/ArchiMetrics.Analysis/Metrics/MemberDocumentationFactory.cs
@@ -10,77 +10,95 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.Xml;
+
 namespace ArchiMetrics.Analysis.Metrics
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Collections.Immutable;
-	using System.Linq;
-	using System.Threading;
-	using System.Threading.Tasks;
-	using System.Xml.Linq;
-	using Common;
-	using Common.Metrics;
-	using Microsoft.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using Common;
+    using Common.Metrics;
+    using Microsoft.CodeAnalysis;
 
-	internal class MemberDocumentationFactory : IAsyncFactory<ISymbol, IMemberDocumentation>
-	{
-		private static readonly MethodKind[] ChildMethods = new[] { MethodKind.PropertyGet, MethodKind.PropertySet, MethodKind.EventAdd, MethodKind.EventRemove };
+    internal class MemberDocumentationFactory : IAsyncFactory<ISymbol, IMemberDocumentation>
+    {
+        private static readonly MethodKind[] ChildMethods = new[]
+            {MethodKind.PropertyGet, MethodKind.PropertySet, MethodKind.EventAdd, MethodKind.EventRemove};
 
-		/// <summary>
-		/// Creates the requested instance as an asynchronous operation.
-		/// </summary>
-		/// <param name="memberSymbol">The memberSymbol to pass to the object creation.</param>
-		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to use for cancelling the object creation.</param>
-		/// <returns>Returns a <see cref="Task{T}"/> which represents the instance creation task.</returns>
-		public Task<IMemberDocumentation> Create(ISymbol memberSymbol, CancellationToken cancellationToken)
-		{
-			var doc = GetDocumentationText(memberSymbol);
-			if (string.IsNullOrWhiteSpace(doc))
-			{
-				return Task.FromResult<IMemberDocumentation>(null);
-			}
+        /// <summary>
+        /// Creates the requested instance as an asynchronous operation.
+        /// </summary>
+        /// <param name="memberSymbol">The memberSymbol to pass to the object creation.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to use for cancelling the object creation.</param>
+        /// <returns>Returns a <see cref="Task{T}"/> which represents the instance creation task.</returns>
+        public Task<IMemberDocumentation> Create(ISymbol memberSymbol, CancellationToken cancellationToken)
+        {
+            var doc = GetDocumentationText(memberSymbol);
+            if (string.IsNullOrWhiteSpace(doc))
+            {
+                return Task.FromResult<IMemberDocumentation>(null);
+            }
 
-			var xmldoc = XDocument.Parse(doc);
-			var docRoot = xmldoc.Root;
-			if (docRoot == null)
-			{
-				return Task.FromResult<IMemberDocumentation>(null);
-			}
+            var docRoot = TryParseXmlComment(doc);
+            if (docRoot == null)
+            {
+                return Task.FromResult<IMemberDocumentation>(new FaultMemberDocumentation(doc));
+            }
 
-			var summaryElement = docRoot.Element("summary");
-			var summary = summaryElement == null ? string.Empty : summaryElement.Value.Trim();
-			var codeElement = docRoot.Element("code");
-			var code = codeElement == null ? string.Empty : codeElement.Value.Trim();
-			var exampleElement = docRoot.Element("example");
-			var example = exampleElement == null ? string.Empty : exampleElement.Value.Trim();
-			var remarksElement = docRoot.Element("remarks");
-			var remarks = remarksElement == null ? string.Empty : remarksElement.Value.Trim();
-			var returnsElement = docRoot.Element("returns");
-			var returns = returnsElement == null ? string.Empty : returnsElement.Value.Trim();
-			var typeParameterElements = docRoot.Elements("typeparam");
-			var parameterElements = docRoot.Elements("param")
-				.Select(_ => new KeyValuePair<string, string>(_.Attribute("name").Value.Trim(), _.Value.Trim()))
-				.ToDictionary(_ => _.Key, _ => _.Value);
-			var typeConstraints = GetTypeContraints(memberSymbol);
-			var typeParameters =
-				typeParameterElements.Select(
-					x =>
-					{
-						var name = x.Attribute("name").Value.Trim();
-						return new TypeParameterDocumentation(
-							name,
-							typeConstraints.ContainsKey(name) ? typeConstraints[name] : null,
-							x.Value.Trim());
-					});
-			var parameters = GetParameters(memberSymbol as IMethodSymbol, parameterElements);
-			var exceptionElements = docRoot.Elements("exception");
-			var exceptions = exceptionElements.Select(x => new ExceptionDocumentation(x.Attribute("cref").Value.Trim(), x.Value.Trim()));
+            var summaryElement = docRoot.Element("summary");
+            var summary = summaryElement == null ? string.Empty : summaryElement.Value.Trim();
+            var codeElement = docRoot.Element("code");
+            var code = codeElement == null ? string.Empty : codeElement.Value.Trim();
+            var exampleElement = docRoot.Element("example");
+            var example = exampleElement == null ? string.Empty : exampleElement.Value.Trim();
+            var remarksElement = docRoot.Element("remarks");
+            var remarks = remarksElement == null ? string.Empty : remarksElement.Value.Trim();
+            var returnsElement = docRoot.Element("returns");
+            var returns = returnsElement == null ? string.Empty : returnsElement.Value.Trim();
+            var typeParameterElements = docRoot.Elements("typeparam");
+            var parameterElements = docRoot.Elements("param")
+                .Select(_ => new KeyValuePair<string, string>(_.Attribute("name").Value.Trim(), _.Value.Trim()))
+                .ToDictionary(_ => _.Key, _ => _.Value);
+            var typeConstraints = GetTypeContraints(memberSymbol);
+            var typeParameters =
+                typeParameterElements.Select(
+                    x =>
+                    {
+                        var name = x.Attribute("name").Value.Trim();
+                        return new TypeParameterDocumentation(
+                            name,
+                            typeConstraints.ContainsKey(name) ? typeConstraints[name] : null,
+                            x.Value.Trim());
+                    });
+            var parameters = GetParameters(memberSymbol as IMethodSymbol, parameterElements);
+            var exceptionElements = docRoot.Elements("exception");
+            var exceptions =
+                exceptionElements.Select(
+                    x => new ExceptionDocumentation(x.Attribute("cref").Value.Trim(), x.Value.Trim()));
 
-			var documentation = new MemberDocumentation(summary, code, example, remarks, returns, typeParameters, parameters, exceptions);
+            var documentation = new MemberDocumentation(summary, code, example, remarks, returns, typeParameters,
+                parameters, exceptions);
 
-			return Task.FromResult<IMemberDocumentation>(documentation);
-		}
+            return Task.FromResult<IMemberDocumentation>(documentation);
+        }
+
+        private static XElement TryParseXmlComment(string xml)
+        {
+            try
+            {
+                var xmldoc = XDocument.Parse(xml);
+                return xmldoc.Root;
+            }
+            catch (XmlException)
+            {
+                return null;
+            }
+	    }
 
 		/// <summary>
 		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.


### PR DESCRIPTION
fix for malformed XML comments as discussed in issue #13 

I've not included the changes I needed to make to project.json as they are not relevant

I've tested this against a project containing invalid XML comments. 

Don't know what's happened to the diffs. Maybe something funny with line endings. There's only a few lines changed
